### PR TITLE
Add support for SmallMolecule for Biolink v2.1.0 (deprecate ChemicalSubstance)

### DIFF
--- a/__test__/unittest/entity_object.test.ts
+++ b/__test__/unittest/entity_object.test.ts
@@ -19,6 +19,14 @@ describe("Test EntityObject class", () => {
         expect(entity.id_prefixes).toContain("UMLS");
     })
 
+    test("If input entity is SmallMolecule, should add additonal ID prefixes in addtion to provided ones", () => {
+        const entity = new Entity("SmallMolecule", {
+            "id_prefixes": ["CHEMBL.COMPOUND"]
+        })
+        // expect(entity.id_prefixes).toContain("CHEMBL.COMPOUND");
+        expect(entity.id_prefixes).toContain("UMLS");
+    })
+
     test("If input entity is Disease, should add additonal ID prefixes in addition to provided ones", () => {
         const entity = new Entity("Disease", {
             "id_prefixes": ["KEGG"]

--- a/__test__/unittest/entity_object.test.ts
+++ b/__test__/unittest/entity_object.test.ts
@@ -1,46 +1,46 @@
 import Entity from '../../src/object/entity_object';
 
 describe("Test EntityObject class", () => {
-    test("If input entity is Gene, should add additonal ID prefixes in addtion to provided ones", () => {
-        const entity = new Entity("Gene", {
-            "id_prefixes": ["NCBIGene"]
-        })
-        expect(entity.id_prefixes).toContain("NCBIGene");
-        expect(entity.id_prefixes).toContain("UMLS");
-        expect(entity.id_prefixes).toContain("SYMBOL");
-        expect(entity.id_prefixes).toContain("OMIM");
+  test("If input entity is Gene, should add additonal ID prefixes in addtion to provided ones", () => {
+    const entity = new Entity("Gene", {
+      "id_prefixes": ["NCBIGene"]
     })
+    expect(entity.id_prefixes).toContain("NCBIGene");
+    expect(entity.id_prefixes).toContain("UMLS");
+    expect(entity.id_prefixes).toContain("SYMBOL");
+    expect(entity.id_prefixes).toContain("OMIM");
+  })
 
-    test("If input entity is ChemicalSubstance, should add additonal ID prefixes in addtion to provided ones", () => {
-        const entity = new Entity("ChemicalSubstance", {
-            "id_prefixes": ["CHEMBL.COMPOUND"]
-        })
-        expect(entity.id_prefixes).toContain("CHEMBL.COMPOUND");
-        expect(entity.id_prefixes).toContain("UMLS");
+  test("If input entity is ChemicalSubstance, should add additonal ID prefixes in addtion to provided ones", () => {
+    const entity = new Entity("ChemicalSubstance", {
+      "id_prefixes": ["CHEMBL.COMPOUND"]
     })
+    expect(entity.id_prefixes).toContain("CHEMBL.COMPOUND");
+    expect(entity.id_prefixes).toContain("UMLS");
+  })
 
-    test("If input entity is SmallMolecule, should add additonal ID prefixes in addtion to provided ones", () => {
-        const entity = new Entity("SmallMolecule", {
-            "id_prefixes": ["CHEMBL.COMPOUND"]
-        })
-        // expect(entity.id_prefixes).toContain("CHEMBL.COMPOUND");
-        expect(entity.id_prefixes).toContain("UMLS");
+  test("If input entity is SmallMolecule, should add additonal ID prefixes in addtion to provided ones", () => {
+    const entity = new Entity("SmallMolecule", {
+      "id_prefixes": ["CHEMBL.COMPOUND"]
     })
+    // expect(entity.id_prefixes).toContain("CHEMBL.COMPOUND");
+    expect(entity.id_prefixes).toContain("UMLS");
+  })
 
-    test("If input entity is Disease, should add additonal ID prefixes in addition to provided ones", () => {
-        const entity = new Entity("Disease", {
-            "id_prefixes": ["KEGG"]
-        })
-        expect(entity.id_prefixes).toHaveLength(2);
-        expect(entity.id_prefixes).toContain("KEGG");
-        expect(entity.id_prefixes).toContain("GARD");
+  test("If input entity is Disease, should add additonal ID prefixes in addition to provided ones", () => {
+    const entity = new Entity("Disease", {
+      "id_prefixes": ["KEGG"]
     })
+    expect(entity.id_prefixes).toHaveLength(2);
+    expect(entity.id_prefixes).toContain("KEGG");
+    expect(entity.id_prefixes).toContain("GARD");
+  })
 
-    test("If input entity is not Gene or ChemicalSubstance, should just return provided ones", () => {
-        const entity = new Entity("PhenotypicFeature", {
-            "id_prefixes": ["HP"]
-        })
-        expect(entity.id_prefixes).toHaveLength(1);
-        expect(entity.id_prefixes).toContain("HP");
+  test("If input entity is not Gene or ChemicalSubstance, should just return provided ones", () => {
+    const entity = new Entity("PhenotypicFeature", {
+      "id_prefixes": ["HP"]
     })
+    expect(entity.id_prefixes).toHaveLength(1);
+    expect(entity.id_prefixes).toContain("HP");
+  })
 })

--- a/src/object/entity_object.ts
+++ b/src/object/entity_object.ts
@@ -18,6 +18,8 @@ export default class Entity extends BaseObject implements BioLinkEntityObject {
   set id_prefixes(idPrefixes: string[]) {
     if (this._name === 'Gene') {
       this._id_prefixes = [...['SYMBOL', 'OMIM', 'UMLS'], ...idPrefixes];
+    } else if (this._name === 'ChemicalSubstance') {
+      this._id_prefixes = typeof idPrefixes === 'undefined' ? ['UMLS'] : [...['UMLS'], ...idPrefixes];
     } else if (this._name === 'SmallMolecule') {
       this._id_prefixes = [...['UMLS'], ...idPrefixes];
     } else if (this._name === 'Disease') {

--- a/src/object/entity_object.ts
+++ b/src/object/entity_object.ts
@@ -18,7 +18,7 @@ export default class Entity extends BaseObject implements BioLinkEntityObject {
   set id_prefixes(idPrefixes: string[]) {
     if (this._name === 'Gene') {
       this._id_prefixes = [...['SYMBOL', 'OMIM', 'UMLS'], ...idPrefixes];
-    } else if (this._name === 'ChemicalSubstance') {
+    } else if (this._name === 'SmallMolecule') {
       this._id_prefixes = [...['UMLS'], ...idPrefixes];
     } else if (this._name === 'Disease') {
       this._id_prefixes = [...['GARD'], ...idPrefixes];


### PR DESCRIPTION
Replaces deprecated ChemicalSubstance case with SmallMolecule case. (addresses #15)