### PR TITLE
Infer non-explicit inverse predicates

### DIFF
--- a/__test__/integration/slot_tree.test.ts
+++ b/__test__/integration/slot_tree.test.ts
@@ -21,7 +21,7 @@ describe("Test BioLink Slot Tree class", () => {
         test("Test all objects are corretly loaded", () => {
             tree.construct();
             expect(tree.objects).toHaveProperty("negatively_regulates");
-            expect(tree.objects.negatively_regulates).toBeInstanceOf(SlotObject)
+            expect(tree.objects.negatively_regulates).toBeInstanceOf(SlotObject);
             expect(tree.objects).toHaveProperty("positively_regulates");
             expect(tree.objects).toHaveProperty("disrupts");
             expect(Object.keys(tree.objects)).toHaveLength(Object.keys(objs).length);
@@ -31,8 +31,15 @@ describe("Test BioLink Slot Tree class", () => {
             tree.construct();
             expect(tree.objects.regulates.children).toContain('negatively_regulates');
             expect(tree.objects.affected_by.children).toContain('disrupted_by');
-            expect(tree.objects.affected_by.children).not.toContain('negatively_regulates')
+            expect(tree.objects.affected_by.children).not.toContain('negatively_regulates');
             expect(tree.objects.negatively_regulates.children).toHaveLength(0);
+        })
+
+        test("Test non-explicit inverses are correctly inferred", () => {
+            tree.construct();
+            expect(tree.objects.gene_associated_with_condition.inverse).toEqual("condition_associated_with_gene");
+            expect(tree.objects.approved_to_treat.inverse).toEqual("approved_for_treatment_by");
+            expect(tree.objects.catalyzes.inverse).toEqual('is_catalyst_of');
         })
     })
 

--- a/src/object/slot_object.ts
+++ b/src/object/slot_object.ts
@@ -28,6 +28,10 @@ export default class Slot extends BaseObject implements BioLinkSlotObject {
     return this._inverse;
   }
 
+  set inverse(value: string) {
+    this._inverse = value;
+  }
+
   get symmetric(): boolean {
     return this._symmetric;
   }

--- a/src/tree/slot_tree.ts
+++ b/src/tree/slot_tree.ts
@@ -20,6 +20,11 @@ export default class BioLinkClassTree extends BaseTree implements BioLinkSlotTre
     this._objects_in_tree[this._modify(name)] = new Slot(this._modify(name), this._objects_in_yaml[name]);
   }
 
+  construct() {
+    super.construct();
+    Object.keys(this._objects_in_tree).map((name: string) => this.inferInverseRelationship(name));
+  }
+
   getDescendants(name: string): BioLinkSlotObject[] {
     return super.getDescendants(name) as BioLinkSlotObject[];
   }
@@ -30,5 +35,16 @@ export default class BioLinkClassTree extends BaseTree implements BioLinkSlotTre
 
   getPath(downstreamNode: string, upstreamNode: string): BioLinkSlotObject[] {
     return super.getPath(downstreamNode, upstreamNode) as BioLinkSlotObject[];
+  }
+
+  protected inferInverseRelationship(name) {
+    if (typeof this._objects_in_tree[this._modify(name)].inverse === 'undefined') {
+      const inverse = Object.values(this._objects_in_tree).find(
+        (obj: BioLinkSlotObject) => obj.inverse === this._modify(name),
+      );
+      if (typeof inverse !== 'undefined') {
+        this._objects_in_tree[this._modify(name)].inverse = inverse.name;
+      }
+    }
   }
 }


### PR DESCRIPTION
*(Bugfix post-addressing biothings/BioThings_Explorer_TRAPI#207)*

Biolink v2.1 does not explicitly define inverses for both predicates in a pair, instead defining the inverse only for one. This leads to a number of predicates showing up as `biolink:undefined` in some queries.

Example query:
```json
{
    "message": {
        "query_graph": {
            "nodes": {
                "n0": {
                    "categories": ["biolink:Disease"]
                },
                "n1": {
                    "ids": ["HGNC:6284"],
		            "categories":["biolink:Gene"]
                }
            },
            "edges": {
                "e0": {
                    "subject": "n0",
                    "object": "n1"
                }
            }
        }
    }
}
```

This PR fixes this issue by inferring these inverses after the `BioLinkSlotTreeObject` has been built.