### PR TITLE
Allow loading of custom biolink files using environment variable

### DIFF
--- a/src/loader/default_loader.ts
+++ b/src/loader/default_loader.ts
@@ -7,7 +7,12 @@ import { BioLinkJSON } from '../types/types';
 
 export default class DefaultLoader extends Loader {
   async load() {
-    const file = await readFile(path.resolve(__dirname, '../../data/biolink.yaml'), { encoding: 'utf8' });
-    return this.yaml2json(file) as BioLinkJSON;
+    const biolink_path = process.env.BIOLINK_FILE
+      ? path.resolve(process.env.BIOLINK_FILE)
+      : path.resolve(__dirname, '../../data/biolink.yaml');
+    const file = await readFile(biolink_path, { encoding: 'utf8' });
+    return (
+      ['.yaml', '.yml'].includes(path.extname(biolink_path)) ? this.yaml2json(file) : JSON.parse(file)
+    ) as BioLinkJSON;
   }
 }

--- a/src/loader/sync_default_loader.ts
+++ b/src/loader/sync_default_loader.ts
@@ -5,7 +5,12 @@ import { BioLinkJSON } from '../types/types';
 
 export default class SyncDefaultLoader extends Loader {
   load() {
-    const file = fs.readFileSync(path.resolve(__dirname, '../../data/biolink.yaml'), { encoding: 'utf8' });
-    return this.yaml2json(file) as BioLinkJSON;
+    const biolink_path = process.env.BIOLINK_FILE
+      ? path.resolve(process.env.BIOLINK_FILE)
+      : path.resolve(__dirname, '../../data/biolink.yaml');
+    const file = fs.readFileSync(biolink_path, { encoding: 'utf8' });
+    return (
+      ['.yaml', '.yml'].includes(path.extname(biolink_path)) ? this.yaml2json(file) : JSON.parse(file)
+    ) as BioLinkJSON;
   }
 }


### PR DESCRIPTION
*(addresses #20)*

By setting the environment variable `BIOLINK_FILE` to an arbitrary absolute path, YAML (.yaml or .yml) or JSON, a custom biolink file may be loaded.

A related PR is on the way to address biothings/bte_trapi_query_graph_handler#30.