### PR TITLE
Identify BTE via User-Agent

### DIFF
--- a/__test__/integration/url_loader.test.ts
+++ b/__test__/integration/url_loader.test.ts
@@ -1,8 +1,10 @@
+import axios from 'axios';
 import URLLoader from '../../src/loader/url_loader';
 import path from 'path';
 
 describe("Test URL Loader", () => {
     test("BioLink yaml should be read from data/ folder and convert to json", async () => {
+        axios.defaults.adapter = require('axios/lib/adapters/http');
         const loader = new URLLoader();
         const res = await loader.load('https://raw.githubusercontent.com/biolink/biolink-model/master/biolink-model.yaml');
         expect(res).toHaveProperty('id', 'https://w3id.org/biolink/biolink-model');

--- a/src/loader/url_loader.ts
+++ b/src/loader/url_loader.ts
@@ -7,8 +7,10 @@ export default class URLLoader extends Loader {
   async load(input) {
     let res;
     try {
+      const userAgent = `BTE/${process.env.NODE_ENV === 'production' ? 'prod' : 'dev'} Node/${process.version} ${process.platform}`;
       res = await axios.get(input, {
         responseType: 'text',
+        headers: { 'User-Agent': userAgent },
       });
     } catch (err) {
       throw new FileLoadingError(`Failed to load BioLink Model. Query to ${input} raise an exception.`);


### PR DESCRIPTION
Identifies BTE via the User-Agent header when making API calls (See biothings/call-apis.js/pull/37 for structure).