### PR TITLE
Add is_mixin property

### DIFF
--- a/src/object/base_object.ts
+++ b/src/object/base_object.ts
@@ -5,12 +5,14 @@ export default abstract class BaseObject implements BioLinkObject {
   protected _parent: string;
   protected _children: string[];
   protected _name: string;
+  protected _is_mixin: boolean;
 
   constructor(name: string, info: BioLinkBase) {
     this._name = name;
     this._description = info.description;
     this._parent = info.is_a;
     this._children = [];
+    this._is_mixin = info.mixin;
   }
 
   get parent(): string {
@@ -23,6 +25,10 @@ export default abstract class BaseObject implements BioLinkObject {
 
   get name(): string {
     return this._name;
+  }
+
+  get is_mixin(): boolean {
+    return this._is_mixin;
   }
 
   get children(): string[] {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -23,6 +23,7 @@ export interface BioLinkObject {
   children: string[];
   description: string;
   name: string;
+  is_mixin: boolean;
   addChild(child: string): void;
 }
 


### PR DESCRIPTION
Adds the property `is_mixin` to all biolink model objects, allowing identification of mixins where appropriate.

Required for biothings/bte_trapi_query_graph_handler/pull/91.